### PR TITLE
fix to read real image size

### DIFF
--- a/Sources/ChangeMenuBarColor/Commands/Abstract/Command.swift
+++ b/Sources/ChangeMenuBarColor/Commands/Abstract/Command.swift
@@ -56,6 +56,18 @@ class Command {
             Log.error("Cannot read the currently set macOS wallpaper. Try providing a specific wallpaper as a parameter instead.")
             return nil
         }
+        
+        var maxImageSize = NSSize(width: 0, height: 0)
+        for i in 0...(wallpaper.representations.count-1)
+        {
+                let rep = wallpaper.representations[i]
+                let imageSize = NSSize(width: rep.pixelsWide, height: rep.pixelsHigh)
+                if (imageSize.width >= maxImageSize.width) || (imageSize.height >= maxImageSize.height)
+                {
+                    maxImageSize = imageSize
+                }
+        }
+        wallpaper.size = maxImageSize
 
         Log.debug("Using currently set macOS wallpaper \(path)")
 


### PR DESCRIPTION
Attribute size of NSImage did not always contain the real image size but returns a size information that is screen resolution dependent and those value can be fractional. To get the real image size it is needed to iterate over the representations array of type NSImageRep and find the largest size in this array.
 
Those fractional values that NSImage size originally returned lead to side effects like like a white line on the border after rescaling. So this pull request is an attempt to fix issue #30.